### PR TITLE
Capitalize "swift" in markdown

### DIFF
--- a/nbs/01_matmul.ipynb
+++ b/nbs/01_matmul.ipynb
@@ -126,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can initialize a tensor in lots of different ways because in swift, two functions with the same name can coexist as long as they don't have the same signatures. Different named arguments give different signatures, so all of those are different `init` functions of `Tensor`:"
+    "We can initialize a tensor in lots of different ways because in Swift, two functions with the same name can coexist as long as they don't have the same signatures. Different named arguments give different signatures, so all of those are different `init` functions of `Tensor`:"
    ]
   },
   {


### PR DESCRIPTION
Swift is capitalized in all other mentions in the markdown text, so this would make this mention consistent.